### PR TITLE
Escape control characters

### DIFF
--- a/src/Seine/Writer/OfficeOpenXML2007/SheetHelper.php
+++ b/src/Seine/Writer/OfficeOpenXML2007/SheetHelper.php
@@ -100,7 +100,7 @@ final class SheetHelper
                 } else {
                     if ($this->shouldUseInlineStrings) {
                         // Use inline string to be more memory efficient
-                        $out .= ' t="inlineStr"><is><t>' . $cell . '</t></is></c>' . MyWriter::EOL;
+                        $out .= ' t="inlineStr"><is><t>' . Utils::escape($cell) . '</t></is></c>' . MyWriter::EOL;
                     } else {
                         $sharedStringId = $this->sharedStrings->writeString($cell);
                         $out .= ' t="s"><v>' . $sharedStringId . '</v></c>' . MyWriter::EOL;


### PR DESCRIPTION
Excel crashes if it encounters unescaped control characters.
So when creating the sharedStrings.xml file, we need to make sure we encode all control characters to be Excel compatible.
